### PR TITLE
Publicly Accessible API Documentation via Swagger vulnerability remediation doc

### DIFF
--- a/src/content/docs/security/swagger-api-security-updates.md
+++ b/src/content/docs/security/swagger-api-security-updates.md
@@ -1,4 +1,6 @@
-# Swagger API Security Updates
+---
+title:  Swagger API Security updates
+---
 
 ## Overview
 This document outlines the changes made to address potential vulnerabilities related to the Swagger API documentation in the Doubtfire application.
@@ -16,7 +18,7 @@ If this vulnerability is not addressed, unauthorized users could access the Swag
 - **Action Taken:** Added a conditional check in the Swagger initializer to ensure that Swagger is only accessible in development environments.
 
 ### Context for the Decision
-- During testing, I attempted to access Swagger documentation on the production site by manipulating the URL to `https://ontrack.deakin.edu.au/home/api/swagger_doc.json` and `https://ontrack.deakin.edu.au/home/swagger_doc.json`. However, I observed that any such attempts were redirected back to `https://ontrack.deakin.edu.au/home`, indicating that Swagger is not needed in production or there are additional protective meassures not included in the Thothtech vesrion of Ontrack.
+- During testing, I attempted to access Swagger documentation on the production site by manipulating the URL to `https://ontrack.deakin.edu.au/home/api/swagger_doc.json` and `https://ontrack.deakin.edu.au/home/swagger_doc.json`. However, I observed that any such attempts were redirected back to `https://ontrack.deakin.edu.au/home`, indicating that Swagger is not needed in production or there are additional protective measures not included in the Thothtech version of Ontrack.
 
 ## Affected Components
 The following components and files were updated as part of this security enhancement:


### PR DESCRIPTION
# Description

This change addresses a vulnerability where Swagger API documentation was publicly accessible in production environments. Swagger has now been **disabled in production** to prevent unauthorised users from discovering sensitive backend routes and internal API details.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Attempted to access Swagger documentation endpoints (`/api/swagger_doc.json`, `/swagger_doc.json`) in a production environment.  
- Verified that requests are redirected to the homepage (`/home`) and Swagger documentation is no longer exposed.  
- Confirmed that Swagger remains available and functional in **development environments** for testing and debugging purposes.  

## Testing Checklist

- [x] Tested in latest Chrome  

## Checklist

- [x] My code follows the style guidelines of this project  
- [x] I have performed a self-review of my code  
- [x] I have commented my code in hard-to-understand areas  
- [x] I have made corresponding changes to the documentation  
- [x] My changes generate no new warnings  
- [x] I have requested a review from security and project maintainers on the Pull Request
