### PR TITLE
ci: update node version and add build check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,13 +10,14 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Linelint
         uses: fernandrone/linelint@master
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.14.2
+          node-version: 20
+          cache: npm
       - name: Install dependencies
         run: npm install
       - name: Prettier
@@ -29,3 +30,8 @@ jobs:
           rm vale.tar.gz
           vale --version
           npm run prose:check
+
+      - name: Build
+        run: npm run build
+
+        


### PR DESCRIPTION
# Description

This PR updates the CI workflow to use newer GitHub Actions versions, and upgrades Node to v20 LTS. It also adds a build step so that CI verifies the Astro site builds successfully during pull requests.

The previous CI workflow configuration used an EOL version of Node (v16.14.2), therefore no longer receiving security updates. Updating to Node v20 improves overall security and stability.

Fixes: N/A

## Type of change 

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This was tested locally to ensure there were no issues. The following commands were run:

```bash
npm install
npm run format:check
npm run build
```

All commands completed successfully, resulting in the expected output.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
