### PR TITLE
fix(config): add site URL for sitemap generation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,8 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-
+  site: 'https://ontrackdocumentation.netlify.app',
+  
   server: {
     host: true
   },


### PR DESCRIPTION
# Description

This PR adds the 'site' configuration option to 'astro.config.mjs' to support sitemap generation.

The build previously produced a warning that the sitemap integration requires the 'site' Astro config option. This was resolved by adding the documentation site URL within the file.

Build before changes; warning:
<img width="573" height="168" alt="npm run build warning" src="https://github.com/user-attachments/assets/9a539ac6-f4a5-43d2-a846-fe01c65cfee3" />

Build after changes; no warning:
<img width="585" height="250" alt="npm run build no astro warnjng" src="https://github.com/user-attachments/assets/3928bb8e-0599-45be-a1bd-b0114945028d" />


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The following command was run locally:

```bash

npm run build

```

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
