### PR TITLE
fix(config): enable sitemap generation

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,8 +3,7 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-  site: 'https://ontrackdocumentation.netlify.app',
-  
+
   server: {
     host: true
   },
@@ -35,7 +34,7 @@ export default defineConfig({
           ],
         },
         {
-          label: 'Intial Setup',
+          label: 'Initial Setup',
           autogenerate: {
             directory: '/setup',
           },
@@ -45,7 +44,7 @@ export default defineConfig({
               link: '/frontend/page',
             },
             {
-              label: 'OnTrack Intial Setup Guidance',
+              label: 'OnTrack Initial Setup Guidance',
               link: '/setup/set',
             },
           ],

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -3,7 +3,8 @@ import starlight from '@astrojs/starlight';
 
 // https://astro.build/config
 export default defineConfig({
-
+  site: 'https://ontrackdocumentation.netlify.app',
+  
   server: {
     host: true
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/check": "^0.5.10",
+        "@astrojs/sitemap": "^3.6.0",
         "@astrojs/starlight": "^0.21.5",
         "astro": "^4.3.5",
         "sharp": "^0.32.5",
@@ -159,12 +160,12 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.0.tgz",
-      "integrity": "sha512-+qxjUrz6Jcgh+D5VE1gKUJTA3pSthuPHe6Ao5JCxok794Lewx8hBFaWHtOnN0ntb2lfOf7gvOi9TefUswQ/ZVA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.6.0.tgz",
+      "integrity": "sha512-4aHkvcOZBWJigRmMIAJwRQXBS+ayoP5z40OklTXYXhUDhwusz+DyDl+nSshY6y9DvkVEavwNcFO8FD81iGhXjg==",
       "license": "MIT",
       "dependencies": {
-        "sitemap": "^8.0.2",
+        "sitemap": "^8.0.0",
         "stream-replace-string": "^2.0.0",
         "zod": "^3.25.76"
       }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.5.10",
+    "@astrojs/sitemap": "^3.6.0",
     "@astrojs/starlight": "^0.21.5",
     "astro": "^4.3.5",
     "sharp": "^0.32.5",


### PR DESCRIPTION
# Description

This PR adds the 'site' configuration option to 'astro.config.mjs' to support sitemap generation.

The build previously produced a warning that the sitemap integration requires the 'site' Astro config option. This was resolved by adding the documentation site URL within the file.

Build before changes; warning:
<img width="573" height="168" alt="npm run build warning" src="https://github.com/user-attachments/assets/9a539ac6-f4a5-43d2-a846-fe01c65cfee3" />


Build after changes; no warning:
<img width="585" height="250" alt="npm run build no astro warnjng" src="https://github.com/user-attachments/assets/3928bb8e-0599-45be-a1bd-b0114945028d" />


This was previously submitted as a separate PR, however enabling sitemap generation saw a Netlify build failure within the `@astrojs/sitemap` integration, meaning the site did not build. To resolve this, a compatible sitemap package was installed (`@astrojs/sitemap v3.6.0`) and tested locally with no new warnings.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as
      expected)
- [ ] Documentation (update or new)

## How Has This Been Tested?

This was tested locally by running:

```bash

npm run build
```

This was also tested after creation of the PR, in which GitHub performed checks and all tests passed.

## Testing Checklist

- [ ] Tested in latest Chrome
- [ ] Tested in latest Safari
- [ ] Tested in latest Firefox

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have requested a review from ... on the Pull Request
